### PR TITLE
fix spec and doc for format_email_address/2

### DIFF
--- a/lib/bamboo/formatter.ex
+++ b/lib/bamboo/formatter.ex
@@ -56,7 +56,7 @@ defprotocol Bamboo.Formatter do
   """
 
   @doc ~S"""
-  Receives data and opts and returns a string or a two item tuple `{name, address}`
+  Receives data and opts and returns a string, a two item tuple `{name, address}`, or a list of either.
 
   opts is a map with the key `:type` and a value of
   `:from`, `:to`, `:cc` or `:bcc`. You can pattern match on this to customize
@@ -65,7 +65,7 @@ defprotocol Bamboo.Formatter do
 
   @type opts :: %{optional(:type) => :from | :to | :cc | :bcc}
 
-  @spec format_email_address(any, opts) :: Bamboo.Email.address()
+  @spec format_email_address(any, opts) :: Bamboo.Email.address() | Bamboo.Email.address_list()
   def format_email_address(data, opts)
 end
 

--- a/lib/bamboo/formatter.ex
+++ b/lib/bamboo/formatter.ex
@@ -65,7 +65,7 @@ defprotocol Bamboo.Formatter do
 
   @type opts :: %{optional(:type) => :from | :to | :cc | :bcc}
 
-  @spec format_email_address(any, opts) :: Bamboo.Email.address() | Bamboo.Email.address_list()
+  @spec format_email_address(any, opts) :: Bamboo.Email.address_list()
   def format_email_address(data, opts)
 end
 


### PR DESCRIPTION
Another fix to add to your dialyzer PR.

`format_email_address` can return a single address [or a list](https://github.com/hazen/bamboo/compare/add-dialyxir-1.1.0-support...nonrational:formatter-spec?expand=1#diff-eba08d6b6b2b7cfc26802f4b50eec0d71e73cb7c5ed0919a561acaf65d0d672eL74) which is already specified by the `Bamboo.Email.address_list` type.